### PR TITLE
Read value for Voice Silence Penalty, fixing replay parsing

### DIFF
--- a/Heroes.ReplayParser/MPQFiles/ReplayInitData.cs
+++ b/Heroes.ReplayParser/MPQFiles/ReplayInitData.cs
@@ -277,7 +277,7 @@
 					if (reader.ReadBoolean() && userID.HasValue) // m_hasSilencePenalty
                         replay.ClientListByUserID[userID.Value].IsSilenced = true;
 
-                    if (replay.ReplayBuild >=61872 && reader.ReadBoolean() && userID.HasValue) // m_hasVoiceSilencePenalty
+                    if (replay.ReplayBuild >= 61718 && reader.ReadBoolean() && userID.HasValue) // m_hasVoiceSilencePenalty
                         replay.ClientListByUserID[userID.Value].IsVoiceSilence = true;
 
                     if (replay.ReplayVersionMajor >= 2)

--- a/Heroes.ReplayParser/MPQFiles/ReplayInitData.cs
+++ b/Heroes.ReplayParser/MPQFiles/ReplayInitData.cs
@@ -277,7 +277,10 @@
 					if (reader.ReadBoolean() && userID.HasValue) // m_hasSilencePenalty
                         replay.ClientListByUserID[userID.Value].IsSilenced = true;
 
-					if(replay.ReplayVersionMajor >= 2)
+                    if (replay.ReplayBuild >=61872 && reader.ReadBoolean() && userID.HasValue) // m_hasVoiceSilencePenalty
+                        replay.ClientListByUserID[userID.Value].IsVoiceSilence = true;
+
+                    if (replay.ReplayVersionMajor >= 2)
 					{
 						Encoding.UTF8.GetString(reader.ReadBlobPrecededWithLength(9)); // m_banner
 						Encoding.UTF8.GetString(reader.ReadBlobPrecededWithLength(9)); // m_spray

--- a/Heroes.ReplayParser/Player.cs
+++ b/Heroes.ReplayParser/Player.cs
@@ -91,6 +91,11 @@ namespace Heroes.ReplayParser
         public bool IsSilenced { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets if the player has been given the voice silence penalty
+        /// </summary>
+        public bool IsVoiceSilence { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the player's selected Hero talents
         /// </summary>
         public Talent[] Talents { get; set; } = new Talent[0];


### PR DESCRIPTION
This fixes the following error:
System.IndexOutOfRangeException: 'Index was outside the bounds of the array'
at MPQFiles/ReplayInitData.cs, line 242: replay.ClientListByWorkingSetSlotID[workingSetSlotID.Value]
